### PR TITLE
making changes for python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.6'
 install:
 - pip install -r requirements.txt
 - pip install coveralls

--- a/ponyexpress/courier.py
+++ b/ponyexpress/courier.py
@@ -1,11 +1,9 @@
 '''
 Base carrier class and helper objects.
 '''
-import os, requests, json
+import requests, json
 import xml.etree.ElementTree as et
 from xml.etree.ElementTree import ParseError
-from datetime import datetime as dt
-from exceptions import NotImplementedError, SyntaxError, ValueError
 
 from ponyexpress.config import JSON_RESPONSE
 

--- a/ponyexpress/rates.py
+++ b/ponyexpress/rates.py
@@ -45,7 +45,7 @@ class Package(object):
         if isinstance(value, tuple):
             self._weight = value
         else:
-            self._weight = ((value / 16), (value % 16))
+            self._weight = ((value // 16), (value % 16))
 
     # Returns the 'Size' of the `Package`, which could be LARGE or REGULAR. If any dimention
     # exceeds 12", then the `Package` is considered LARGE.
@@ -82,7 +82,7 @@ class RateCalculationResponse(object):
     # Adds `RateCalculations` to the response
     def add(self, *rates):
         # Extend the list of results with the new ones
-        if len(rates):
+        if rates:
             self.rates.extend(rates)
 
     # Returns the `RateCalculation` associated with the lowest price
@@ -107,7 +107,7 @@ class RateOption(object):
         self.price = float(price)
 
         # Unpack potentially unknow values
-        for key, val in kwargs.iteritems():
+        for key, val in kwargs.items():
             setattr(self, key, val)
 
 

--- a/ponyexpress/tracking.py
+++ b/ponyexpress/tracking.py
@@ -57,33 +57,33 @@ class TrackingResponse(object):
 
 
 class TrackingEvent(object):
-        '''
-        Contains basic information associated with the status of a package/letter.
+    '''
+    Contains basic information associated with the status of a package/letter.
 
-        ## Attributes
-        `type` - The current status of the item, such as, SHIPPED, DELIVERED, RECEIVED, etc. Will always be in CAPS.
-        `date` - The UTC date that this event occured on. Default parse format is `%m-%d-%Y`, 06-29-2015.
-        `time` - The UTC time that this event occured at. Default parse format is '%H:%M:%S', 17:35:59.
-        `state` - The state/province/region which this event happend in.
-        `city` - The city within the above state whic this event happend in.
-        `postal_code` - The zip/postal code associated with the particular area within the above city.
-        '''
+    ## Attributes
+    `type` - The current status of the item, such as, SHIPPED, DELIVERED, RECEIVED, etc. Will always be in CAPS.
+    `date` - The UTC date that this event occured on. Default parse format is `%m-%d-%Y`, 06-29-2015.
+    `time` - The UTC time that this event occured at. Default parse format is '%H:%M:%S', 17:35:59.
+    `state` - The state/province/region which this event happend in.
+    `city` - The city within the above state whic this event happend in.
+    `postal_code` - The zip/postal code associated with the particular area within the above city.
+    '''
 
-        # Init method for creating a new instance of the TrackingEvent.
-        def __init__(self, state, city, postal_code, etype='UNDEFINED',
-                     date='01-01-1970', time='00:00:00',
-                     date_format='%m-%d-%Y', time_format='%H:%M:%S'):
-            self.type = etype.upper()
-            self.date = dt.strptime(date, date_format).date()
-            self.time = dt.strptime(time, time_format).time()
-            self.state = state.title()
-            self.city = city.title()
-            self.postal_code = postal_code
+    # Init method for creating a new instance of the TrackingEvent.
+    def __init__(self, state, city, postal_code, etype='UNDEFINED',
+                 date='01-01-1970', time='00:00:00',
+                 date_format='%m-%d-%Y', time_format='%H:%M:%S'):
+        self.type = etype.upper()
+        self.date = dt.strptime(date, date_format).date()
+        self.time = dt.strptime(time, time_format).time()
+        self.state = state.title()
+        self.city = city.title()
+        self.postal_code = postal_code
 
-        @property
-        def datetime(self):
-            return dt.combine(self.date, self.time)
+    @property
+    def datetime(self):
+        return dt.combine(self.date, self.time)
 
-        # Returns a nice string representation of the date and time
-        def isoDatetime(self, date_format='%B %d, %Y', time_format='%I:%M %p'):
-            return self.datetime.strftime(' '.join([date_format, time_format]))
+    # Returns a nice string representation of the date and time
+    def isoDatetime(self, date_format='%B %d, %Y', time_format='%I:%M %p'):
+        return self.datetime.strftime(' '.join([date_format, time_format]))

--- a/ponyexpress/usps.py
+++ b/ponyexpress/usps.py
@@ -1,5 +1,6 @@
-import HTMLParser, re
-from exceptions import TypeError
+import re
+from html.parser import HTMLParser
+from builtins import str
 
 from ponyexpress.address import AddressValidationResponse, Address
 from ponyexpress.config import XML_RESPONSE
@@ -70,7 +71,7 @@ class USPSCourier(BaseCourier):
         super(USPSCourier, self).process_exception(error)
 
     '''
-    USPS Address Validation V4 API. Returns one or many `Address` objects depending on the validity of 
+    USPS Address Validation V4 API. Returns one or many `Address` objects depending on the validity of
     the user provided information, and whether the response was valid.
 
     ## Parameters
@@ -222,13 +223,13 @@ class USPSCourier(BaseCourier):
                 id='0',
                 origin_zip=package.origin,
                 destination_zip=package.destination,
-                weight_lb=unicode(package.weight[0]),
-                weight_oz=unicode(package.weight[1]),
+                weight_lb=str(package.weight[0]),
+                weight_oz=str(package.weight[1]),
                 shape=package.shape,
                 size=package.size,
-                width=unicode(package.width),
-                length=unicode(package.length),
-                height=unicode(package.height)
+                width=str(package.width),
+                length=str(package.length),
+                height=str(package.height)
             )
 
         # The reason we format the method second is so that the getDetailedRates code can speicify without going crazy with string parsing.
@@ -257,7 +258,7 @@ class USPSCourier(BaseCourier):
                 RateCalculation(
                     package,
                     rate.find('Rate').text,
-                    HTMLParser.HTMLParser().unescape(rate.find('MailService').text)
+                    HTMLParser().unescape(rate.find('MailService').text)
                 )
             )
 
@@ -301,7 +302,7 @@ class USPSCourier(BaseCourier):
         new_rate = RateCalculation(
             rate.package,
             postage_info.find('Rate').text,
-            HTMLParser.HTMLParser().unescape(postage_info.find('MailService').text)
+            HTMLParser().unescape(postage_info.find('MailService').text)
         )
 
         # For each of the options provided, add it to the options

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.7.0
 mkdocs==0.14.0
+future==0.16.0

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,6 @@
 import os
 from datetime import datetime as dt
 from unittest import TestCase
-from exceptions import NotImplementedError, SyntaxError
 
 from ponyexpress.address import Address
 from ponyexpress.config import XML_RESPONSE

--- a/tests/test_usps.py
+++ b/tests/test_usps.py
@@ -1,5 +1,4 @@
 import os
-from exceptions import NotImplementedError, TypeError
 from datetime import datetime as dt
 from unittest import TestCase
 
@@ -93,5 +92,4 @@ class USPSTests(TestCase):
         # Get the detailed options for all of the shipping methods available for USPS
         for rate in response.rates:
             detailed_rate = self.usps.getDetailedRate(rate)
-
-        self.assertEqual(rate.price, detailed_rate.price)
+            self.assertEqual(rate.price, detailed_rate.price)


### PR DESCRIPTION
importing from exceptions is unnecessary in python 2.7 and not available in python 3.
HTMLParser is now html.parser, catching the import error is pretty standard to differentiate the versions via ducking.